### PR TITLE
New actions, and improved instance creation

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -95,7 +95,7 @@ Number IDs are always interpreted as indexes, even if a layer or playlist has a 
 
 | Action          | Description                                                  |
 | --------------- | ------------------------------------------------------------ |
-| Select Layer    | Selects the layer in PVP.  <br />Set `Target Layer`to `Yes` to make the layer the target of untargeted media. |
+| Select Layer    | Selects the layer in PVP.  <br>Set `Target Layer`to `Yes` to make the layer the target of untargeted media. |
 | Select Playlist | Selects the playlist.                                        |
 
 
@@ -115,13 +115,19 @@ Number IDs are always interpreted as indexes, even if a layer or playlist has a 
 
 | Action                  | Description                                                  |
 | ----------------------- | ------------------------------------------------------------ |
+| Go to Layer Offset (Seconds) | Skips the layer's playing media to a specific offset. Positive numbers indicate the offset is from the start, and negative numbers from the end.  <br>Examples: `5` moves to 5 seconds from the start. `-5` moves to 5 seconds from the end. `0` moves to the start. `-0` moves to the end. |
 | Layer Blend Mode        | Sets the layer's blend mode. The default blend mode is `Normal`. |
-| Layer Opacity           | Sets the layer's opacity by percentage; a whole number from `0` to `100`.  <br />You can also make relative opacity adjustments by prefixing the value with a `+` or `-`. |
+| Layer Opacity           | Sets the layer's opacity by percentage; a whole number from `0` to `100`.  <br>You can also make relative opacity adjustments by prefixing the value with a `+` or `-`. |
 | Layer Preset            | Applies a preset to the specified layer. Leave the `Preset Name` option empty to unlink the layer's preset. |
-| Layer Target Set        | Changes the layer's target set.  <br />A PVP bug prevents target sets from being addressed by index. It can only be addressed by its name. |
-| Layer Effect Preset     | Sets the layer's effect preset by its name.  <br />Leave the `Effect Preset Name` field empty to clear all effects. |
+| Layer Target Set        | Changes the layer's target set.  <br>A PVP bug prevents target sets from being addressed by index. It can only be addressed by its name. |
+| Layer Transition Duration (Seconds) | Sets the transition duration of a layer. |
+| Layer Effect Preset     | Sets the layer's effect preset by its name.  <br>Leave the `Effect Preset Name` field empty to clear all effects. |
+| Pause Layer             | Pauses the media playing in the layer. |
+| Play Layer              | Plays/resumes the media playing in the layer. |
+| Skip Media in Layer (Seconds) | Skips the layer's playing media back or forward some number of seconds. Negative _Seconds_ skips back.  <br>Use decimals to skip back fractions of seconds; `-1.5` will skip back one-and-a-half seconds. |
 | Track Matte             | (PVP 3.3+) Sets the layer's blend mode (how it blends with the layer immediately under it). Can't be used on the base layer. The `White Matte` mode doesn't support the `Invert Matte` option. |
-| Workspace Effect Preset | Sets the workspace's effect preset by its name.<br />Leave the `Effect Preset Name` field empty to clear all effects. |
+| Workspace Effect Preset | Sets the workspace's effect preset by its name.<br>Leave the `Effect Preset Name` field empty to clear all effects. |
+| Workspace Transition Duration (Seconds) | Sets the transition duration of the workspace. |
 
 
 ## Error Codes

--- a/HELP.md
+++ b/HELP.md
@@ -120,14 +120,20 @@ Number IDs are always interpreted as indexes, even if a layer or playlist has a 
 | Layer Opacity           | Sets the layer's opacity by percentage; a whole number from `0` to `100`.  <br>You can also make relative opacity adjustments by prefixing the value with a `+` or `-`. |
 | Layer Preset            | Applies a preset to the specified layer. Leave the `Preset Name` option empty to unlink the layer's preset. |
 | Layer Target Set        | Changes the layer's target set.  <br>A PVP bug prevents target sets from being addressed by index. It can only be addressed by its name. |
-| Layer Transition Duration (Seconds) | Sets the transition duration of a layer. |
+| Layer Transition Duration (Seconds) | Sets the transition duration of a layer. See _Transition Duration Note_ below. |
 | Layer Effect Preset     | Sets the layer's effect preset by its name.  <br>Leave the `Effect Preset Name` field empty to clear all effects. |
 | Pause Layer             | Pauses the media playing in the layer. |
 | Play Layer              | Plays/resumes the media playing in the layer. |
 | Skip Media in Layer (Seconds) | Skips the layer's playing media back or forward some number of seconds. Negative _Seconds_ skips back.  <br>Use decimals to skip back fractions of seconds; `-1.5` will skip back one-and-a-half seconds. |
 | Track Matte             | (PVP 3.3+) Sets the layer's blend mode (how it blends with the layer immediately under it). Can't be used on the base layer. The `White Matte` mode doesn't support the `Invert Matte` option. |
 | Workspace Effect Preset | Sets the workspace's effect preset by its name.<br>Leave the `Effect Preset Name` field empty to clear all effects. |
-| Workspace Transition Duration (Seconds) | Sets the transition duration of the workspace. |
+| Workspace Transition Duration (Seconds) | Sets the transition duration of the workspace. See _Transition Duration Note_ below. |
+
+
+#### Transition Duration Note
+Any layer or workspace that uses the `Default` transition in PVP shares that same duration property. For example, if **Layer 1**, **Layer 2** and **Workspace [Master]** use the `Default` transition, then changing the duration of any one of them will change all the others.
+
+Give each layer its own transition, like **Dissolve**, if you want to be able to control them separately.
 
 
 ## Error Codes

--- a/HELP.md
+++ b/HELP.md
@@ -21,8 +21,8 @@ Open Preferences in PVP, switch to the Network tab, and enable network API suppo
 
 Enter in the IP address and port PVP is running on:
 
-- **PVP IP**: The IP address of the PVP instance you want to control.
-- **HTTPS Connection**: Check if PVP's `Use HTTPS Connection` is checked.
+- **PVP Host**: The IP address or hostname of the PVP instance you want to control.
+- **Use HTTPS** Check if PVP's `Use HTTPS Connection` is checked.
 - **Authentication Token**: The `Authentication Token` as shown in PVP's Network Preferences, **only if** PVP's `Require Authentication` is checked.
 - **Port**: The port PVP is running on.
 
@@ -34,8 +34,8 @@ If you only have a single PVP instance, leave the following fields empty.
 
 If you have two PVP installations that are running in a primary/backup mode, you may want actions to go to each PVP install to keep them in sync. Instead of creating two PVP instances in Companion and adding the same action for both instances, just add the backup PVP's connection information and let the module handle the work for you:
 
-- **PVP IP (Backup instance)**: The IP address of the backup PVP instance.
-- **HTTPS Connection**: Check if the backup instance requires an `HTTP Connection`.
+- **PVP Host (Backup instance)**: The IP address of the backup PVP instance.
+- **Use HTTPS**: Check if the backup instance requires an `HTTP Connection`.
 - **Authentication Token**: The `Authentication Token` for the backup instance.
 - **Port**: The port the backup instance.
 
@@ -163,4 +163,4 @@ The included Presets can be used to quickly create basic buttons for Layers and 
 
 ------
 
-For additional actions, please raise a feature request on [GitHub](https://github.com/bitfocus/companion-module-pvp/).
+For additional actions, please raise a feature request on [GitHub](https://github.com/bitfocus/companion-module-renewedvision-pvp).

--- a/index.js
+++ b/index.js
@@ -84,14 +84,14 @@ instance.prototype.config_fields = function() {
 		{
 			type: 'textinput',
 			id: 'host',
-			label: 'PVP IP',
+			label: 'PVP Host',
 			width: 4,
-			regex: self.REGEX_IP
+			required: true
 		},
 		{
 			type: 'checkbox',
 			id: 'https',
-			label: 'HTTPS Connection',
+			label: 'Use HTTPS',
 			width: 2,
 			tooltip: 'Check if PVP requires an HTTPS connection.',
 			default: false
@@ -103,13 +103,12 @@ instance.prototype.config_fields = function() {
 			width: 4
 		},
 		{
-			type: 'number',
+			type: 'textinput',
 			id: 'port',
 			label: 'Port',
-			min: 1,
-			max: 65535,
 			width: 2,
-			required: true
+			required: true,
+			regex: this.REGEX_PORT
 		},
 		{
 			type: 'text',
@@ -121,15 +120,14 @@ instance.prototype.config_fields = function() {
 		{
 			type: 'textinput',
 			id: 'host_backup',
-			label: 'PVP IP (Backup instance)',
+			label: 'PVP Host (Backup instance)',
 			width: 4,
-			// Regex borrowed from instance_skel's REGEX_IP, but made optional
-			regex: '/^((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))?$/'
+			required: false
 		},
 		{
 			type: 'checkbox',
 			id: 'https_backup',
-			label: 'HTTPS Connection',
+			label: 'Use HTTPS',
 			width: 2,
 			tooltip: 'Check if PVP requires an HTTPS connection.',
 			default: false
@@ -141,13 +139,12 @@ instance.prototype.config_fields = function() {
 			width: 4
 		},
 		{
-			type: 'number',
+			type: 'textinput',
 			id: 'port_backup',
 			label: 'Port',
 			width: 2,
-			min: 1,
-			max: 65535,
-			required: false
+			required: false,
+			regex: this.REGEX_PORT,
 		}
 	];
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"pvp"
 	],
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software"


### PR DESCRIPTION
**New actions**
- Pause and play/resume layer (#15).
- Layer/workspace transition duration (#14).
- Skip media in layer: Skips the layer's playing media back or forward some number of seconds.
- Go to layer offset: Skips the layer's playing media to a specific offset in seconds.

**New presets**
- Pause
- Play/resume

**Other**
- PVP hosts can be configured using DNS/hostname, as well as by IP.
- Instance creation could get into an awkward state if no backup instance was configured.
- Updated HELP.md
- Version bump

Tested with PVP 3.3.x and 3.4.x.

Resolves #15, resolves #14